### PR TITLE
this stops things from blowing up if you use a Net::HTTP object for multiple connections

### DIFF
--- a/lib/always_verify_ssl_certificates.rb
+++ b/lib/always_verify_ssl_certificates.rb
@@ -9,7 +9,9 @@ module Net
         s = timeout(@open_timeout) { TCPSocket.open(conn_address(), conn_port()) }
         D "opened"
         if use_ssl?
-          self.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          if self.verify_mode != OpenSSL::SSL::VERIFY_PEER
+            self.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          end
           s = OpenSSL::SSL::SSLSocket.new(s, @ssl_context)
           s.sync_close = true
         end


### PR DESCRIPTION
hurrah, no more kaboom like https://gist.github.com/e5c31961e9dffb0d6189
